### PR TITLE
Update snowflake connector

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(name="pipelinewise-target-snowflake",
       python_requires='>=3.7',
       install_requires=[
           'pipelinewise-singer-python==1.*',
-          'snowflake-connector-python[pandas]==3.0.4',
+          'snowflake-connector-python[pandas]==3.15.0',
           'inflection==0.5.1',
           'joblib==1.2.0',
           'boto3==1.28.20',


### PR DESCRIPTION
## Problem

Snowflake python connector has a bug causing certificate validation failure, returning the following error:
```
snowflake.connector.errors.OperationalError: 254007: The certificate is revoked or could not be validated: hostname=sfc-se-ds1-2-customer-stage.s3.amazonaws.com
```
## Proposed changes

Update `snowflake-connector-python[pandas]` to `3.15.0`, which fixes the issue.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)