### PR TITLE
PLT-687: Honour vars.CI_RUNNER on standalone workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   lint_and_test:
     name: Linting and Testing
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     strategy:
       matrix:
         python-version: [ 3.7, 3.8, 3.9 ]
@@ -34,7 +34,7 @@ jobs:
 
   integration_test:
     name: Integration Testing
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     environment: ci_tests
     strategy:
       matrix:

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python


### PR DESCRIPTION
## What

Makes the workflows in this repo that define their **own** `runs-on` honour the org-wide
`CI_RUNNER` variable, so CI can be moved off GitHub-hosted runners without editing this repo again.

```yaml
# jobs that already had the dropdown
runs-on: ${{ inputs.runner || vars.CI_RUNNER || 'ubuntu-latest' }}

# jobs with no dropdown (pull_request / push / release only)
runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
```

| Precedence | Source | Use |
|---|---|---|
| 1 | `inputs.runner` — the dropdown, where one exists | one run, picked by a human |
| 2 | `vars.CI_RUNNER` — org variable | the emergency lever, moves all CI at once |
| 3 | `ubuntu-latest` | normal operation |

## Behaviour today is unchanged

`CI_RUNNER` is currently set to `ubuntu-latest`, so every job resolves exactly as before. This
change only makes the org variable *reachable* — nothing moves until someone changes its value.

## Why these files needed editing at all

Most repos inherit this for free from `brocc-ab/shared-workflows`. The workflows changed here call
no shared workflow — they own their `runs-on`, so the fallback has to be written inline.

The ones with no `workflow_dispatch` are the important case: `type: choice` is dispatch-only and the
`inputs` context is empty on `pull_request` / `push` / `release`, so a dropdown is impossible for
them. The org variable is the only mechanism that reaches them.

## Only Linux amd64 defaults are touched

`brocc-runner` is an amd64 Linux ARC scale set. Rewriting anything else would change what the job
runs on, so only bare `ubuntu-latest` and the existing `inputs.runner || 'ubuntu-latest'` pattern
were rewritten. Left exactly as-is:

- `windows-latest` and macOS jobs
- arm64 runners
- CodeBuild runners (`codebuild-github-runner-*`)
- jobs already pinned to `brocc-runner`
- explicit version pins such as `ubuntu-20.04` — that is a deliberate OS choice, not "the default
  runner", and redirecting it would change the test environment

## Verified programmatically

Every file was parsed before and after; the new expressions were normalised back to what they
replaced and the remaining document asserted identical to `HEAD`. Every `runs-on` that was *not*
rewritten was asserted byte-identical to the original, so no non-Linux or pinned job moved.
25 files, 35 jobs rewritten, 0 unexpected changes.

PLT-687
